### PR TITLE
Ease transition to new LCMType functionality.

### DIFF
--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -23,6 +23,9 @@ export LCM,
        encode,
        decode,
        decode!,
+       size_fields, # deprecated
+       check_valid, # deprecated
+       fingerprint, # will soon no longer be exported
        subscribe,
        unsubscribe,
        handle,


### PR DESCRIPTION
I've made sure that this works with HumanoidLCMSim. Unfortunately, I had to undo my rename of `check_valid` to `checkvalid`, because we need the old `check_valid` definitions to be more specific than the new generated function. 

There will be no depwarns unless you explicitly call the `size_fields` function yourself, so this can be a patch release. The downside is that downstream users won't be warned about switching to using `@lcmtypesetup`, but I think it's more important to have a good transition release.