### PR TITLE
Upgrade liblcm to fix subscription capacity off-by-one bug

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -59,7 +59,7 @@ end
 provides(Yum,
     Dict("glib" => glib))
 
-lcm_sha = "9e53469cd0713ca8fbf37a968f6fd314f5f11584"
+lcm_sha = "0e6472188332bf5683d1ccdd29ba6855ac3cd593"
 lcm_folder = "lcm-$(lcm_sha)"
 
 provides(Sources,

--- a/src/core.jl
+++ b/src/core.jl
@@ -174,6 +174,10 @@ function set_queue_capacity(sub::Subscription, capacity::Integer)
     return status == 0
 end
 
+function get_queue_size(sub::Subscription)
+    ccall((:lcm_subscription_get_queue_size, liblcm), Cint, (Ptr{Void},), sub)
+end
+
 lcm_handle(lcm::LCM) = ccall((:lcm_handle, liblcm), Cint, (Ptr{Void},), lcm)
 
 function handle(lcm::LCM)


### PR DESCRIPTION
This is possible now that https://github.com/lcm-proj/lcm/issues/167 is fixed