### PR TITLE
fix errors and deprecations on v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false
 branches:
   only:
     - master
-matrix:
- allow_failures:
- - julia: nightly
+# matrix:
+#  allow_failures:
+#  - julia: nightly
 after_success:
   - julia -e 'cd(Pkg.dir("LCMCore")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ notifications:
 branches:
   only:
     - master
-# matrix:
-#  allow_failures:
-#  - julia: nightly
+matrix:
+ allow_failures:
+ - julia: 0.7  # due to bugs fixed after 0.7.beta
 after_success:
   - julia -e 'cd(Pkg.dir("LCMCore")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,6 @@
-julia 0.6
+julia 0.7-alpha
 BinDeps 0.4.0
 @osx Homebrew 0.3.0
 CMakeWrapper 0.0.1
-Compat 0.27
 StaticArrays 0.5
 BufferedStreams 0.4

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 using BinDeps
 using CMakeWrapper
-using Compat
+using Pkg
 
 @BinDeps.setup
 
@@ -20,7 +20,7 @@ end
 # Explicitly disallow global LCM installations
 validate_lcm(name, handle) = contains(name, dirname(@__FILE__))
 
-@static if Compat.Sys.islinux()
+@static if Sys.islinux()
     deps = [
         python = library_dependency("python", aliases=["libpython2.7.so", "libpython3.2.so", "libpython3.3.so", "libpython3.4.so", "libpython3.5.so", "libpython3.6.so", "libpython3.7.so", "libpython3.8.so"], validate=cflags_validator("python", "python2", "python3"))
         glib = library_dependency("glib", aliases=["libglib-2.0-0", "libglib-2.0", "libglib-2.0.so.0"], depends=[python], validate=cflags_validator("glib-2.0"))
@@ -45,10 +45,7 @@ lcm_cmake_arguments = [
     "-DLCM_ENABLE_EXAMPLES:BOOL=OFF"
 ]
 
-@static if Compat.Sys.isapple()
-    if Pkg.installed("Homebrew") === nothing
-        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
-    end
+@static if Sys.isapple()
     using Homebrew
     provides(Homebrew.HB, "glib", glib, os=:Darwin)
     push!(lcm_cmake_arguments,

--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -2,9 +2,12 @@ __precompile__()
 
 module LCMCore
 
-using Compat
 using StaticArrays
 using BufferedStreams
+
+using Dates
+using FileWatching: poll_fd
+import Base: unsafe_convert, close
 
 depsjl = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if !isfile(depsjl)
@@ -13,8 +16,6 @@ else
     include(depsjl)
 end
 
-import Base: unsafe_convert, close
-using Base.Dates: Period, Millisecond
 export LCM,
        LCMType,
        publish,

--- a/src/core.jl
+++ b/src/core.jl
@@ -30,10 +30,10 @@ end
 loopback_interface() = chomp(readstring(pipeline(`ifconfig`, `grep -m 1 -i loopback`, `cut -d : -f1`)))
 
 function loopback_multicast_setup_advice(lo::AbstractString)
-    if Compat.Sys.isapple()
+    if Sys.isapple()
         """Consider running (as root):
         route add -net 224.0.0.0 -netmask 240.0.0.0 -interface $lo"""
-    elseif Compat.Sys.islinux()
+    elseif Sys.islinux()
         """Consider running (as root):
         ifconfig $lo multicast
         route add -net 224.0.0.0 netmask 240.0.0.0 dev lo"""
@@ -57,9 +57,9 @@ function check_loopback_multicast(lo::AbstractString)
 end
 
 function check_multicast_routing(lo::AbstractString)
-    routing_correct = if Compat.Sys.isapple()
+    routing_correct = if Sys.isapple()
         chomp(readstring(pipeline(`route get 224.0.0.0 -netmask 240.0.0.0`, `grep -m 1 -i interface`, `cut -f2 -d :`, `tr -d ' '`))) == lo
-    elseif Compat.Sys.islinux()
+    elseif Sys.islinux()
         chomp(readstring(pipeline(`ip route get 224.0.0.0`, `grep -m 1 -i dev`, `sed 's/.*dev\s*//g'`, `cut -d ' ' -f1`))) == lo
     else
         error("Sorry, I only know how to check multicast routing on Linux and macOS")

--- a/src/core.jl
+++ b/src/core.jl
@@ -12,9 +12,9 @@ end
 
 struct Subscription{T <: SubscriptionOptions}
     options::T
-    csubscription::Ptr{Void}
+    csubscription::Ptr{Cvoid}
 end
-unsafe_convert(::Type{Ptr{Void}}, sub::Subscription) = sub.csubscription
+unsafe_convert(::Type{Ptr{Cvoid}}, sub::Subscription) = sub.csubscription
 
 # Troubleshooting adapted from:
 # https://github.com/RobotLocomotion/drake/blob/f72bb3f465f69f25459a7a65c57b45c795b5e31d/drake/matlab/util/setup_loopback_multicast.sh
@@ -80,29 +80,29 @@ end
 
 # must be mutable so that we can attach a finalizer
 mutable struct LCM
-    pointer::Ptr{Void}
+    pointer::Ptr{Cvoid}
     provider::String
     filedescriptor::RawFD
     subscriptions::Vector{Subscription}
 
     LCM(provider="") = begin
-        pointer = ccall((:lcm_create, liblcm), Ptr{Void}, (Ptr{UInt8},), provider)
+        pointer = ccall((:lcm_create, liblcm), Ptr{Cvoid}, (Ptr{UInt8},), provider)
         if pointer == C_NULL
             troubleshoot()
         end
-        filedescriptor = RawFD(ccall((:lcm_get_fileno, liblcm), Cint, (Ptr{Void},), pointer))
+        filedescriptor = RawFD(ccall((:lcm_get_fileno, liblcm), Cint, (Ptr{Cvoid},), pointer))
         lcm = new(pointer, provider, filedescriptor, Subscription[])
-        finalizer(lcm, close)
+        finalizer(close, lcm)
         lcm
     end
 end
-unsafe_convert(::Type{Ptr{Void}}, lcm::LCM) = lcm.pointer
+unsafe_convert(::Type{Ptr{Cvoid}}, lcm::LCM) = lcm.pointer
 
 isgood(lcm::LCM) = lcm.pointer != C_NULL
 
 function close(lcm::LCM)
     if isgood(lcm)
-        ccall((:lcm_destroy, liblcm), Void, (Ptr{Void},), lcm)
+        ccall((:lcm_destroy, liblcm), Cvoid, (Ptr{Cvoid},), lcm)
         lcm.pointer = C_NULL
     end
 end
@@ -122,7 +122,7 @@ function publish(lcm::LCM, channel::AbstractString, msg::T) where T
 end
 
 function publish(lcm::LCM, channel::AbstractString, data::Vector{UInt8})
-    status = ccall((:lcm_publish, liblcm), Cint, (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Cuint), lcm, channel, data, length(data))
+    status = ccall((:lcm_publish, liblcm), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ptr{UInt8}, Cuint), lcm, channel, data, length(data))
     return status == 0
 end
 
@@ -132,53 +132,53 @@ struct RecvBuf
     data::Ptr{UInt8}
     data_size::UInt32
     recv_utime::Int64
-    lcm::Ptr{Void}
+    lcm::Ptr{Cvoid}
 end
 
 function onresponse(rbuf::RecvBuf, channelbytes::Ptr{UInt8}, opts::SubscriptionOptions{T}) where T
     channel = unsafe_string(channelbytes)
     msgdata = unsafe_wrap(Vector{UInt8}, rbuf.data, rbuf.data_size)
-    if isa(T, Type{Void})
+    if T === Nothing
         opts.handler(channel, msgdata)
     else
         msg = decode(msgdata, opts.msgtype)
         opts.handler(channel, msg)
     end
-    return nothing::Void
+    return nothing
 end
 
 function subscribe(lcm::LCM, channel::String, options::T) where T <: SubscriptionOptions
-    csubscription = ccall((:lcm_subscribe, liblcm), Ptr{Void},
-        (Ptr{Void}, Ptr{UInt8}, Ptr{Void}, Ptr{Void}),
+    csubscription = ccall((:lcm_subscribe, liblcm), Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{UInt8}, Ptr{Cvoid}, Ptr{Cvoid}),
         lcm,
         channel,
-        cfunction(onresponse, Void, Tuple{Ref{RecvBuf}, Ptr{UInt8}, Ref{T}}),
+        @cfunction(onresponse, Cvoid, (Ref{RecvBuf}, Ptr{UInt8}, Ref{T})),
         Ref(options))
     sub = Subscription(options, csubscription)
     push!(lcm.subscriptions, sub)
     sub
 end
 
-function subscribe(lcm::LCM, channel::String, handler, msgtype=Void)
+function subscribe(lcm::LCM, channel::String, handler, msgtype=Nothing)
     subscribe(lcm, channel, SubscriptionOptions(msgtype, handler))
 end
 
 function unsubscribe(lcm::LCM, subscription::Subscription)
-    result = ccall((:lcm_unsubscribe, liblcm), Cint, (Ptr{Void}, Ptr{Void}), lcm, subscription)
+    result = ccall((:lcm_unsubscribe, liblcm), Cint, (Ptr{Cvoid}, Ptr{Cvoid}), lcm, subscription)
     result == 0
 end
 
 function set_queue_capacity(sub::Subscription, capacity::Integer)
     @assert capacity >= 0
-    status = ccall((:lcm_subscription_set_queue_capacity, liblcm), Cint, (Ptr{Void}, Cint), sub, capacity)
+    status = ccall((:lcm_subscription_set_queue_capacity, liblcm), Cint, (Ptr{Cvoid}, Cint), sub, capacity)
     return status == 0
 end
 
 function get_queue_size(sub::Subscription)
-    ccall((:lcm_subscription_get_queue_size, liblcm), Cint, (Ptr{Void},), sub)
+    ccall((:lcm_subscription_get_queue_size, liblcm), Cint, (Ptr{Cvoid},), sub)
 end
 
-lcm_handle(lcm::LCM) = ccall((:lcm_handle, liblcm), Cint, (Ptr{Void},), lcm)
+lcm_handle(lcm::LCM) = ccall((:lcm_handle, liblcm), Cint, (Ptr{Cvoid},), lcm)
 
 function handle(lcm::LCM)
     fd = filedescriptor(lcm)

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -52,7 +52,7 @@ defaultval(::Type{T}) where {T<:LCMType} = T()
 defaultval(::Type{Bool}) = false
 defaultval(::Type{T}) where {T<:NetworkByteOrderEncoded} = zero(T)
 defaultval(::Type{String}) = ""
-defaultval(::Type{Array{T, N}}) where {T, N} = Array{T, N}(ntuple(i -> 0, Val(N))...)
+defaultval(::Type{Array{T, N}}) where {T, N} = Array{T, N}(undef, ntuple(i -> 0, Val(N))...)
 defaultval(::Type{SA}) where {T, SA<:StaticArray{<:Any, T}} = _defaultval(SA, T, Length(SA))
 _defaultval(::Type{SA}, ::Type{T}, ::Length{L}) where {SA, T, L} = SA(ntuple(i -> defaultval(T), Val(L)))
 
@@ -199,7 +199,7 @@ end
         Base.@_inline_meta
         newsize = evaldims(x, dimensions(T, $(Val(fieldname)))...)
         if newsize !== size(x.$fieldname)
-            x.$fieldname = Array{S, N}(uninitialized, newsize...)
+            x.$fieldname = Array{S, N}(undef, newsize...)
             @inbounds for i in eachindex(x.$fieldname)
                 x.$fieldname[i] = defaultval(S)
             end
@@ -247,7 +247,7 @@ function decode_in_place end
 
 decode_in_place(::Type{<:LCMType}) = true
 @generated function decodefield!(x::T, io::IO) where T<:LCMType
-    field_assignments = Vector{Expr}(fieldcount(x))
+    field_assignments = Vector{Expr}(undef, fieldcount(x))
     for (i, fieldname) in enumerate(fieldnames(x))
         F = fieldtype(x, fieldname)
         field_assignments[i] = quote
@@ -323,7 +323,7 @@ function encode(io::IO, x::LCMType)
 end
 
 @generated function encodefield(io::IO, x::LCMType)
-    encode_exprs = Vector{Expr}(fieldcount(x))
+    encode_exprs = Vector{Expr}(undef, fieldcount(x))
     for (i, fieldname) in enumerate(fieldnames(x))
         encode_exprs[i] = :(encodefield(io, x.$fieldname))
     end
@@ -348,8 +348,8 @@ function encodefield(io::IO, A::AbstractArray)
 end
 
 # Sugar
-encode(data::Vector{UInt8}, x::LCMType) = encode(IOBuffer(data, false, true), x)
-encode(x::LCMType) = (stream = IOBuffer(false, true); encode(stream, x); flush(stream); take!(stream))
+encode(data::Vector{UInt8}, x::LCMType) = encode(IOBuffer(data, read=false, write=true), x)
+encode(x::LCMType) = (stream = IOBuffer(read=false, write=true); encode(stream, x); flush(stream); take!(stream))
 
 decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, BufferedInputStream(data))
 decode(data::Vector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)
@@ -413,7 +413,7 @@ macro lcmtypesetup(lcmt, dimensioninfos...)
     # LCMCore.fingerprint method
     fingerprint = quote
         let hash = reinterpret(Int64, LCMCore.computehash($lcmt, DataType[]))
-            LCMCore.fingerprint(::Type{$lcmt}) = hash
+            @eval LCMCore.fingerprint(::Type{$lcmt}) = $(Expr(:$, :hash))
         end
     end
 
@@ -430,11 +430,11 @@ function make_fixed_dimensions_methods(::Type{T}) where T<:LCMType
         if F <: Array
             # skip
         elseif F <: StaticArray
-            let dimtuple = LCMCore.makedim.(size(F))
-                LCMCore.dimensions(::Type{T}, ::Val{field}) = dimtuple
+            @eval let dimtuple = LCMCore.makedim.(size($F))
+                LCMCore.dimensions(::Type{$T}, ::Val{$(QuoteNode(field))}) = dimtuple
             end
         else
-            LCMCore.dimensions(::Type{T}, ::Val{field}) = ()
+            @eval LCMCore.dimensions(::Type{$T}, ::Val{$(QuoteNode(field))}) = ()
         end
     end
 end

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -413,7 +413,7 @@ macro lcmtypesetup(lcmt, dimensioninfos...)
     # LCMCore.fingerprint method
     fingerprint = quote
         let hash = reinterpret(Int64, LCMCore.computehash($lcmt, DataType[]))
-            @eval LCMCore.fingerprint(::Type{$lcmt}) = $(Expr(:$, :hash))
+            LCMCore.fingerprint(::Type{$lcmt}) = hash
         end
     end
 

--- a/src/readlog.jl
+++ b/src/readlog.jl
@@ -1,7 +1,7 @@
 # Read LCM log files directly
 
 mutable struct lcm_eventlog_t
-  f::Ptr{Void}
+  f::Ptr{Cvoid}
   eventcount::Int64 #Clonglong
 end
 
@@ -29,7 +29,7 @@ end
 function lcm_eventlog_destroy(_log::Ptr{lcm_eventlog_t})
   ccall(
     (:lcm_eventlog_destroy, LCMCore.liblcm),
-    Void,
+    Cvoid,
     (Ptr{lcm_eventlog_t}, ),
     _log
   )
@@ -75,7 +75,7 @@ isgood(_log::Ptr{lcm_eventlog_t}) = _log != C_NULL
 isgood(lcmlog::LCMLog) = isgood(lcmlog._log)
 isgood(_event::Ptr{lcm_eventlog_event_t}) = _event != C_NULL
 
-function read_next_event(lcmlog::LCMLog)::Union{Void, lcm_eventlog_event_t}
+function read_next_event(lcmlog::LCMLog)::Union{Nothing, lcm_eventlog_event_t}
   _event = lcm_eventlog_read_next_event(lcmlog._log)
   if isgood(_event)
     return unsafe_load(_event)
@@ -101,7 +101,7 @@ function handle(lcmlog::LCMLog)::Bool
     return false
 end
 
-function subscribe(lcmlog::LCMLog, channel::S, callback::F, msgtype=Void) where {S <: AbstractString, F <: Function}
+function subscribe(lcmlog::LCMLog, channel::S, callback::F, msgtype=Nothing) where {S <: AbstractString, F <: Function}
   opts = LCMCore.LCMCore.SubscriptionOptions(msgtype, callback)
   lcmlog.subscriptions[channel] = opts
   nothing

--- a/test/lcmtypes/lcmtesttypes.jl
+++ b/test/lcmtypes/lcmtesttypes.jl
@@ -4,6 +4,7 @@ export lcm_test_type_1, lcm_test_type_2, lcm_test_type_3, polynomial_t, polynomi
 export hard_coded_example
 
 using LCMCore, StaticArrays
+using Random: randstring
 
 mutable struct lcm_test_type_1 <: LCMType
     a::Int16
@@ -190,7 +191,7 @@ function Base.rand(::Type{polynomial_matrix_t})
 end
 
 function hard_coded_example(::Type{polynomial_matrix_t})
-    polynomials = Matrix{polynomial_t}(2, 1)
+    polynomials = Matrix{polynomial_t}(undef, 2, 1)
     polynomials[1] = polynomial_t(1234, 4, [5.0, 0.0, 1.0, 3.0])
     polynomials[2] = polynomial_t(1234, 4, [10.0, 0.0, 2.0, 6.0])
     polynomial_matrix_t(1234, 2, 1, polynomials)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
-using Base.Test
+using Test
 using LCMCore
 using StaticArrays
 using BufferedStreams
-using Base.Dates: Second, Millisecond
+using Dates: Second, Millisecond
+using FileWatching: poll_fd
 import LCMCore: encode, decode
 
 @testset "close multiple times" begin

--- a/test/test_lcmtype.jl
+++ b/test/test_lcmtype.jl
@@ -1,5 +1,6 @@
 using LCMCore
-using Base.Test
+using Test
+using Random
 using StaticArrays
 using BufferedStreams
 
@@ -26,7 +27,7 @@ function test_in_place_decode_noalloc(::Type{T}) where T<:LCMType
 end
 
 @testset "LCMType" begin
-    using lcmtesttypes
+    using .lcmtesttypes
     srand(1)
 
     # Check base hashes (obtained from lcm-gen --debug; note that hash reported by lcm-gen is a **signed** integer (despite the 0x prefix))
@@ -60,7 +61,7 @@ end
 
     # Test against byte blobs that were encoded using pylcm
     for lcmt in [lcm_test_type_1, lcm_test_type_2, lcm_test_type_3, polynomial_t, polynomial_matrix_t]
-        bytes = read(Pkg.dir("LCMCore", "test", "lcmtypes", string(lcmt.name.name) * "_example_bytes"))
+        bytes = read(joinpath(@__DIR__, "lcmtypes", string(lcmt.name.name) * "_example_bytes"))
         @test hard_coded_example(lcmt) == decode(bytes, lcmt)
     end
 


### PR DESCRIPTION
cc @tkoolen 

The only substantial change is that I needed to add an `@eval` around the method definitions in `make_fixed_dimension_methods` since global function methods can no longer be added in a local scope. 

This also raises the minimum Julia version to v0.7-alpha