### PR TITLE
Encoding with zero allocations

### DIFF
--- a/src/EfficientWriteBuffers.jl
+++ b/src/EfficientWriteBuffers.jl
@@ -1,0 +1,58 @@
+module EfficientWriteBuffers
+
+export EfficientWriteBuffer
+
+struct EfficientWriteBuffer <: IO
+    data::Vector{UInt8}
+    position::Base.RefValue{Int}
+end
+
+EfficientWriteBuffer(data::Vector{UInt8}) = EfficientWriteBuffer(data, Ref(0))
+EfficientWriteBuffer() = EfficientWriteBuffer(Vector{UInt8}())
+
+@inline function ensureroom!(buf::EfficientWriteBuffer, n::Integer)
+    resize!(buf.data, buf.position[] + n)
+end
+
+function Base.take!(buf::EfficientWriteBuffer)
+    resize!(buf.data, buf.position[])
+    buf.position[] = 0
+    buf.data
+end
+
+@inline function Base.unsafe_write(buf::EfficientWriteBuffer, p::Ptr{UInt8}, n::UInt)
+    ensureroom!(buf, n)
+    unsafe_copyto!(pointer(buf.data, buf.position[] + 1), p, n)
+    buf.position[] += n
+    Int(n)
+end
+
+Base.@propagate_inbounds function Base.write(buf::EfficientWriteBuffer, x::UInt8)
+    ensureroom!(buf, 1)
+    position = buf.position[] += 1
+    buf.data[position] = x
+    1
+end
+
+Base.@propagate_inbounds Base.write(buf::EfficientWriteBuffer, x::Int8) = write(buf, reinterpret(UInt8, x))
+
+@inline function Base.write(
+            buf::EfficientWriteBuffer,
+            x::Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}) # TODO: more?
+    n = Core.sizeof(x)
+    ensureroom!(buf, n)
+    position = buf.position[]
+    @inbounds for i = Base.OneTo(n) # LLVM unrolls this loop on Julia 0.6.4
+        position += 1
+        buf.data[position] = x % UInt8
+        x = x >>> 8
+    end
+    buf.position[] = position
+    n
+end
+
+@inline Base.write(buf::EfficientWriteBuffer, x::Union{Float16, Float32, Float64}) = write(buf, reinterpret(Unsigned, x))
+
+Base.eof(buf::EfficientWriteBuffer) = true
+
+end

--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -30,9 +30,12 @@ export LCM,
        LCMLog,
        @lcmtypesetup
 
+include("EfficientWriteBuffers.jl")
+using .EfficientWriteBuffers: EfficientWriteBuffer
 
 include("util.jl")
 include("core.jl")
 include("lcmtype.jl")
 include("readlog.jl")
+
 end

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -348,8 +348,8 @@ function encodefield(io::IO, A::AbstractArray)
 end
 
 # Sugar
-encode(data::Vector{UInt8}, x::LCMType) = encode(IOBuffer(data, read=false, write=true), x)
-encode(x::LCMType) = (stream = IOBuffer(read=false, write=true); encode(stream, x); flush(stream); take!(stream))
+encode(data::Vector{UInt8}, x::LCMType) = encode(EfficientWriteBuffer(data), x)
+encode(x::LCMType) = (stream = EfficientWriteBuffer(); encode(stream, x); flush(stream); take!(stream))
 
 decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, BufferedInputStream(data))
 decode(data::Vector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,6 +215,6 @@ end
     @test did_callback2
 end
 
+include("test_EfficientWriteBuffers.jl")
 include("test_lcmtype.jl")
 include("test_readlog.jl")
-

--- a/test/test_EfficientWriteBuffers.jl
+++ b/test/test_EfficientWriteBuffers.jl
@@ -1,0 +1,52 @@
+module EfficientWriteBuffersTest
+
+using Test
+using Random
+using LCMCore: EfficientWriteBuffers.EfficientWriteBuffer
+
+@testset "bitstype numbers" begin
+    for T = [Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128,Float16,Float32,Float64]
+        buf = EfficientWriteBuffer()
+        @test buf.position[] == 0
+        for i = 1 : 2
+            x = rand(T)
+            @test write(buf, x)::Int == Core.sizeof(x)
+            @test buf.position[] == Core.sizeof(x)
+            allocs = @allocated(write(buf, x))
+            if i > 1
+                @test allocs == 0
+            end
+            bytes = take!(buf)
+            readbuf = IOBuffer(bytes)
+            for _ = 1 : 2
+                xback = read(readbuf, T)
+                @test xback == x
+            end
+        end
+        @test eof(buf)
+    end
+end
+
+@testset "strings" begin
+    rng = MersenneTwister(1)
+    buf = EfficientWriteBuffer()
+    for i = 1 : 2
+        take!(buf)
+        str = randstring(rng, 8)
+        allocs = @allocated write(buf, str)
+        if i > 1
+            @test allocs == 0
+        end
+    end
+
+    buf = EfficientWriteBuffer()
+    for i = 1 : 1000
+        str = randstring(rng, 8)
+        @test write(buf, str)::Int == sizeof(str)
+        write(buf, str)
+        strstr = String(take!(buf))
+        @test strstr == str * str
+    end
+end
+
+end


### PR DESCRIPTION
Add `EfficientWriteBuffer`, a faster alternative to `IOBuffer`. Use it to achieve zero allocation for LCM types.

I'm actually considering making this a package now rather than later, so that it's easier to support both 0.6 and 0.7 with the same code. What do you think?