### PR TITLE
Use FastIOBuffers.FastWriteBuffer to achieve zero allocations for encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - osx
 julia:
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
@@ -14,8 +15,8 @@ branches:
     - master
     - /^release-.*$/
 matrix:
- allow_failures:
- - julia: 0.7
+  allow_failures:
+  - julia: 1.0
+  - julia: nightly
 after_success:
-  - julia -e 'cd(Pkg.dir("LCMCore")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-
+- julia --project -e 'Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
   - julia: 1.0
   - julia: nightly
 after_success:
-- julia --project -e 'Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+- julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,4 @@ BinDeps 0.4.0
 @osx Homebrew 0.3.0
 CMakeWrapper 0.0.1
 StaticArrays 0.5
-BufferedStreams 0.4
-FastIOBuffers
+FastIOBuffers 0.0.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ BinDeps 0.4.0
 CMakeWrapper 0.0.1
 StaticArrays 0.5
 BufferedStreams 0.4
+FastIOBuffers

--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -1,7 +1,8 @@
 module LCMCore
 
 using StaticArrays
-using BufferedStreams
+using FastIOBuffers
+using BufferedStreams # TODO: remove, replace BufferedInputStream usages with FastIOBuffers.FastReadBuffer once it exists
 
 using Dates
 using FileWatching: poll_fd

--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -2,7 +2,6 @@ module LCMCore
 
 using StaticArrays
 using FastIOBuffers
-using BufferedStreams # TODO: remove, replace BufferedInputStream usages with FastIOBuffers.FastReadBuffer once it exists
 
 using Dates
 using FileWatching: poll_fd

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -351,7 +351,7 @@ end
 encode(data::Vector{UInt8}, x::LCMType) = encode(FastWriteBuffer(data), x)
 encode(x::LCMType) = (stream = FastWriteBuffer(); encode(stream, x); flush(stream); take!(stream))
 
-decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, BufferedInputStream(data))
+decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, FastReadBuffer(data))
 decode(data::Vector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)
 
 # @lcmtypesetup macro and related functions

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -348,8 +348,8 @@ function encodefield(io::IO, A::AbstractArray)
 end
 
 # Sugar
-encode(data::Vector{UInt8}, x::LCMType) = encode(IOBuffer(data, read=false, write=true), x)
-encode(x::LCMType) = (stream = IOBuffer(read=false, write=true); encode(stream, x); flush(stream); take!(stream))
+encode(data::Vector{UInt8}, x::LCMType) = encode(FastWriteBuffer(data), x)
+encode(x::LCMType) = (stream = FastWriteBuffer(); encode(stream, x); flush(stream); take!(stream))
 
 decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, BufferedInputStream(data))
 decode(data::Vector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using Test
 using LCMCore
 using StaticArrays
-using BufferedStreams
 using Dates: Second, Millisecond
 using FileWatching: poll_fd
 import LCMCore: encode, decode

--- a/test/test_lcmtype.jl
+++ b/test/test_lcmtype.jl
@@ -2,8 +2,7 @@ using LCMCore
 using Test
 using Random
 using StaticArrays
-using BufferedStreams
-using FastIOBuffers
+using FastIOBuffers: FastReadBuffer, FastWriteBuffer, setdata!
 
 include(joinpath(@__DIR__, "lcmtypes", "lcmtesttypes.jl"))
 
@@ -20,10 +19,13 @@ function test_in_place_decode_noalloc(::Type{T}) where T<:LCMType
     in = rand(T)
     bytes = encode(in)
     out = deepcopy(in)
-    decodestream = BufferedInputStream(bytes)
+    decodestream = FastReadBuffer()
+    setdata!(decodestream, bytes)
     decode!(out, decodestream)
-    decodestream = BufferedInputStream(bytes)
-    allocs = @allocated decode!(out, decodestream)
+    allocs = @allocated begin
+        setdata!(decodestream, bytes)
+        decode!(out, decodestream)
+    end
     @test allocs == 0
 end
 


### PR DESCRIPTION
Supersedes #50.

Requires https://github.com/JuliaLang/METADATA.jl/pull/16344.

FastIOBuffers could also just be a test dependency; what's your preference?