### PR TITLE
Store channel name in SubscriptionOptions 

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -138,10 +138,9 @@ end
 
 function check_channel_name(channelptr::Ptr{UInt8}, opts::SubscriptionOptions)
     i = 1
-    while (byte = unsafe_load(channelptr)) != 0x00
-        byte == UInt8(opts.channel[i]) || error("Mismatch between received channel name and subscription channel name")
+    while (byte = unsafe_load(channelptr, i)) != 0x00
+        byte == codeunit(opts.channel, i) || error("Mismatch between received channel name and subscription channel name")
         i += 1
-        channelptr += 1
     end
 end
 

--- a/src/readlog.jl
+++ b/src/readlog.jl
@@ -102,7 +102,7 @@ function handle(lcmlog::LCMLog)::Bool
 end
 
 function subscribe(lcmlog::LCMLog, channel::S, callback::F, msgtype=Nothing) where {S <: AbstractString, F <: Function}
-  opts = LCMCore.LCMCore.SubscriptionOptions(msgtype, callback)
+  opts = SubscriptionOptions(msgtype, callback, channel)
   lcmlog.subscriptions[channel] = opts
   nothing
 end


### PR DESCRIPTION
…and check it rather than using `unsafe_string`, which still allocates.

Also changes `subscribe(lcm, channel, options)` to `subscribe(lcm, options)`, since that info is now already stored in the options. Technically a breaking change, but I doubt anybody was using that method directly.