### PR TITLE
 Avoid allocation in onresponse using UnsafeArrays. 

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ BinDeps 0.8
 CMakeWrapper 0.2
 StaticArrays 0.5
 FastIOBuffers 0.0.1
+UnsafeArrays 0.2.0

--- a/src/LCMCore.jl
+++ b/src/LCMCore.jl
@@ -2,6 +2,7 @@ module LCMCore
 
 using StaticArrays
 using FastIOBuffers
+using UnsafeArrays
 
 using Dates
 using FileWatching: poll_fd

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,6 +214,27 @@ end
     @test did_callback2
 end
 
+@testset "lcm_handle allocations" begin
+    data = UInt8[1,2,3,4,5]
+    channel = "CHANNEL_1"
+
+    # start listening
+    sublcm = LCM()
+    sub = subscribe(sublcm, channel, (c, d) -> nothing)
+    set_queue_capacity(sub, 2)
+
+    # publish two messages
+    publcm = LCM()
+    for _ = 1 : 2
+        publish(publcm, channel, data)
+    end
+
+    # check that handling doesn't allocate
+    LCMCore.lcm_handle(sublcm)
+    allocs = @allocated LCMCore.lcm_handle(sublcm)
+    @test allocs == 0
+end
+
 include("test_lcmtype.jl")
 include("test_readlog.jl")
 


### PR DESCRIPTION
Well that was easy.

I'm not 100% sure the `@preserve` is necessary; I believe the receive buffer is typically owned by the C LCM instance, not by Julia, correct? Can't hurt though, especially if somebody adds e.g. a pure-Julia test case involving `onresponse` at some point.