### PR TITLE
Fix #56, decode breakage after UnsafeArrays change.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ BinDeps 0.8
 @osx Homebrew 0.3.0
 CMakeWrapper 0.2
 StaticArrays 0.5
-FastIOBuffers 0.0.1
+FastIOBuffers 0.2.0
 UnsafeArrays 0.2.0

--- a/src/lcmtype.jl
+++ b/src/lcmtype.jl
@@ -348,11 +348,11 @@ function encodefield(io::IO, A::AbstractArray)
 end
 
 # Sugar
-encode(data::Vector{UInt8}, x::LCMType) = encode(FastWriteBuffer(data), x)
+encode(data::AbstractVector{UInt8}, x::LCMType) = encode(FastWriteBuffer(data), x)
 encode(x::LCMType) = (stream = FastWriteBuffer(); encode(stream, x); flush(stream); take!(stream))
 
-decode!(x::LCMType, data::Vector{UInt8}) = decode!(x, FastReadBuffer(data))
-decode(data::Vector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)
+decode!(x::LCMType, data::AbstractVector{UInt8}) = decode!(x, FastReadBuffer(data))
+decode(data::AbstractVector{UInt8}, ::Type{T}) where {T<:LCMType} = decode!(T(), data)
 
 # @lcmtypesetup macro and related functions
 """

--- a/src/readlog.jl
+++ b/src/readlog.jl
@@ -1,47 +1,43 @@
 # Read LCM log files directly
 
 mutable struct lcm_eventlog_t
-  f::Ptr{Cvoid}
-  eventcount::Int64 #Clonglong
+    f::Ptr{Cvoid}
+    eventcount::Int64 #Clonglong
 end
-
 
 struct lcm_eventlog_event_t
-  eventnum::Int64 #Clonglong
-  timestamp::Int64 #Clonglong
-  channellen::Int32 #Cint
-  datalen::Int32 #Cint
-  channel::Ptr{Cuchar}
-  data::Ptr{Cuchar}
+    eventnum::Int64 #Clonglong
+    timestamp::Int64 #Clonglong
+    channellen::Int32 #Cint
+    datalen::Int32 #Cint
+    channel::Ptr{Cuchar}
+    data::Ptr{Cuchar}
 end
 
-
 function lcm_eventlog_create(file::S where S <: AbstractString)
-  ccall(
+    ccall(
     (:lcm_eventlog_create, LCMCore.liblcm),
     Ptr{lcm_eventlog_t},
     (Cstring, Cstring),
     file, "r"
-  )
+    )
 end
 
-
 function lcm_eventlog_destroy(_log::Ptr{lcm_eventlog_t})
-  ccall(
+    ccall(
     (:lcm_eventlog_destroy, LCMCore.liblcm),
     Cvoid,
     (Ptr{lcm_eventlog_t}, ),
     _log
-  )
+    )
 end
-
 
 function lcm_eventlog_read_next_event(_log::Ptr{lcm_eventlog_t})
     ccall(
-      (:lcm_eventlog_read_next_event, LCMCore.liblcm),
-      Ptr{lcm_eventlog_event_t},
-      (Ptr{lcm_eventlog_t},),
-      _log
+    (:lcm_eventlog_read_next_event, LCMCore.liblcm),
+    Ptr{lcm_eventlog_event_t},
+    (Ptr{lcm_eventlog_t},),
+    _log
     )
 end
 
@@ -49,26 +45,22 @@ end
 # Doesn't work yet
 # event = unsafe_wrap(lcm_eventlog_event_t, _event, dim??)
 
-
-
 mutable struct LCMLog
-  _log::Ptr{lcm_eventlog_t}
-  subscriptions::Dict{AbstractString, LCMCore.SubscriptionOptions}
-  function LCMLog(filename::S) where {S <: AbstractString}
-    _log = lcm_eventlog_create(filename)
-    if !isgood(_log)
-      throw(ArgumentError("Cannot open the LCM log file at: $filename"))
+    _log::Ptr{lcm_eventlog_t}
+    subscriptions::Dict{AbstractString, LCMCore.SubscriptionOptions}
+    function LCMLog(filename::S) where {S <: AbstractString}
+        _log = lcm_eventlog_create(filename)
+        if !isgood(_log)
+            throw(ArgumentError("Cannot open the LCM log file at: $filename"))
+        end
+        return new(_log, Dict{AbstractString, LCMCore.SubscriptionOptions}())
     end
-    return new(_log, Dict{AbstractString, LCMCore.SubscriptionOptions}())
-  end
 end
 
-
-
 function close(lcmlog::LCMLog)
-  if isgood(lcmlog)
-    lcm_eventlog_destroy(lcmlog._log)
-  end
+    if isgood(lcmlog)
+        lcm_eventlog_destroy(lcmlog._log)
+    end
 end
 
 isgood(_log::Ptr{lcm_eventlog_t}) = _log != C_NULL
@@ -76,33 +68,33 @@ isgood(lcmlog::LCMLog) = isgood(lcmlog._log)
 isgood(_event::Ptr{lcm_eventlog_event_t}) = _event != C_NULL
 
 function read_next_event(lcmlog::LCMLog)::Union{Nothing, lcm_eventlog_event_t}
-  _event = lcm_eventlog_read_next_event(lcmlog._log)
-  if isgood(_event)
-    return unsafe_load(_event)
-  end
-  nothing
+    _event = lcm_eventlog_read_next_event(lcmlog._log)
+    if isgood(_event)
+        return unsafe_load(_event)
+    end
+    nothing
 end
 
 function handle(lcmlog::LCMLog)::Bool
     # do memory copy and then check for subscribed channel -- This is not efficient, but easiest to do. TBD is `unsafe_wrap` to avoid memory copy of _event
     event = read_next_event(lcmlog)
     if event != nothing
-      # need a convert from lcm_eventlog_event_t to (RecvBuf, channelbytes, chnlen)
-      rb = LCMCore.RecvBuf(event.data, UInt32(event.datalen), event.timestamp, 0)
-      # need a LCMCore.SubscriptionOptions{T}
-      chn = unsafe_string(event.channel, event.channellen)
-      if haskey(lcmlog.subscriptions, chn)
-        opts = lcmlog.subscriptions[chn]
-        # use onresponse similar to regular live LCM traffic
-        LCMCore.onresponse(rb, event.channel, opts)
-      end
-      return true
+        # need a convert from lcm_eventlog_event_t to (RecvBuf, channelbytes, chnlen)
+        rb = LCMCore.RecvBuf(event.data, UInt32(event.datalen), event.timestamp, 0)
+        # need a LCMCore.SubscriptionOptions{T}
+        chn = unsafe_string(event.channel, event.channellen)
+        if haskey(lcmlog.subscriptions, chn)
+            opts = lcmlog.subscriptions[chn]
+            # use onresponse similar to regular live LCM traffic
+            LCMCore.onresponse(rb, event.channel, opts)
+        end
+        return true
     end
     return false
 end
 
-function subscribe(lcmlog::LCMLog, channel::S, callback::F, msgtype=Nothing) where {S <: AbstractString, F <: Function}
-  opts = SubscriptionOptions(msgtype, callback, channel)
-  lcmlog.subscriptions[channel] = opts
-  nothing
+function subscribe(lcmlog::LCMLog, channel::S, callback::F, msgtype=Nothing) where {S <: AbstractString, F}
+    opts = SubscriptionOptions(msgtype, callback, channel)
+    lcmlog.subscriptions[channel] = opts
+    nothing
 end

--- a/test/mymessage.jl
+++ b/test/mymessage.jl
@@ -1,0 +1,16 @@
+mutable struct MyMessage
+    field1::Int32
+    field2::Float64
+end
+
+function encode(msg::MyMessage)
+    buf = IOBuffer()
+    write(buf, hton(msg.field1))
+    write(buf, hton(msg.field2))
+    buf.data
+end
+
+function decode(data, msg::Type{MyMessage})
+    buf = IOBuffer(data)
+    MyMessage(ntoh(read(buf, Int32)), ntoh(read(buf, Float64)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Dates: Second, Millisecond
 using FileWatching: poll_fd
 import LCMCore: encode, decode
 
+include("mymessage.jl")
+
 @testset "close multiple times" begin
     lcm = LCM()
     close(lcm)
@@ -55,23 +57,6 @@ end
     subscribe(lcm, channel, check_data)
     @async handle(lcm)
     publish(lcm, channel, data)
-end
-
-mutable struct MyMessage
-    field1::Int32
-    field2::Float64
-end
-
-function encode(msg::MyMessage)
-    buf = IOBuffer()
-    write(buf, hton(msg.field1))
-    write(buf, hton(msg.field2))
-    buf.data
-end
-
-function decode(data, msg::Type{MyMessage})
-    buf = IOBuffer(data)
-    MyMessage(ntoh(read(buf, Int32)), ntoh(read(buf, Float64)))
 end
 
 @testset "encode and decode" begin
@@ -237,4 +222,3 @@ end
 
 include("test_lcmtype.jl")
 include("test_readlog.jl")
-

--- a/test/test_lcmtype.jl
+++ b/test/test_lcmtype.jl
@@ -97,3 +97,25 @@ end
     @test d === lcmt2.d
     @test f === lcmt2.f
 end
+
+@testset "LCMType: handle" begin
+    channel = "CHANNEL_1"
+    msg = rand(lcm_test_type_1)
+
+    # start listening
+    sublcm = LCM()
+    check_msg = let expected = msg
+        (channel, msg) -> @test(msg == expected)
+    end
+    sub = subscribe(sublcm, channel, check_msg, lcm_test_type_1)
+    set_queue_capacity(sub, 2)
+
+    # publish two messages
+    publcm = LCM()
+    for _ = 1 : 2
+        publish(publcm, channel, msg)
+    end
+
+    # handle
+    LCMCore.lcm_handle(sublcm)
+end


### PR DESCRIPTION
Also fix indentation and clean up the readlog tests a bit.

- [x] requires https://github.com/JuliaLang/METADATA.jl/pull/19599 (+ lower bound on version)
- [x] needs tests (@GearsAD, could you provide one based on the failure you were seeing in #56?)
